### PR TITLE
Add server-destroy support

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1,12 +1,13 @@
-var async   = require('async');
-var stream  = require('stream');
-var util    = require('util');
-var net     = require('net');
-var merge   = require('merge');
-var through = require('through');
-var hat     = require('hat');
-var es      = require('event-stream');
-var konduit = require('konduit');
+var async         = require('async');
+var stream        = require('stream');
+var util          = require('util');
+var net           = require('net');
+var merge         = require('merge');
+var through       = require('through');
+var hat           = require('hat');
+var es            = require('event-stream');
+var konduit       = require('konduit');
+var enableDestroy = require('server-destroy');
 
 // default options
 var DEFAULTS = {
@@ -25,6 +26,8 @@ function Application(options) {
   self.server      = net.createServer(self._handleInbound.bind(self));
   self.options     = merge(Object.create(DEFAULTS), options);
   self.connections = { inbound: [], outbound: [] };
+
+  enableDestroy(self.server);
 
   // setup middlware stack with initial entry a simple passthrough
   self.stack = [function(socket) {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "async": "^0.9.0",
     "event-stream": "^3.1.7",
     "hat": "0.0.3",
+    "konduit": "^0.0.3",
     "merge": "^1.2.0",
-    "through": "^2.3.6",
-    "konduit": "^0.0.3"
+    "server-destroy": "^1.0.0",
+    "through": "^2.3.6"
   }
 }

--- a/test/application.unit.js
+++ b/test/application.unit.js
@@ -229,4 +229,45 @@ describe('Application', function() {
 
   });
 
+  describe('server#destroy', function () {
+    var app;
+
+    beforeEach(function () {
+      app = coal({
+        logger: stublog,
+        seeds: ['127.0.0.1:12321', '127.0.0.1:23432']
+      });
+    });
+
+    var peer1 = coal({ logger: stublog });
+    var peer2 = coal({ logger: stublog });
+    peer1.listen(12321);
+    peer2.listen(23432);
+
+    it('should destroy the server', function (done) {
+      app.listen(34543, function () {
+        app.peers().length.should.equal(2);
+
+        // give coalescent time to process sockets
+        setTimeout(function () {
+          app.server.destroy(function () {
+              try {
+                app.server.destroy();
+              } catch (e) {
+                e.message.should.equal('Not running');
+                done();
+              }
+          });
+        }, 10);
+      });
+    });
+
+    it('should have freed the address binding, once destroyed', function (done) {
+      app.listen(34543, function () {
+        app.peers().length.should.equal(2);
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
This adds support to coalescent to forcibly destroy a server using the [server-destroy](https://github.com/isaacs/server-destroy) lib.

This was the only implementation I was able to get working. I tried the following implementations as middleware, with no success:

```js
var stream = require('stream');
var util   = require('util');
var enableDestroy = require('server-destroy');

function Destroy() {}

util.inherits(Destroy, stream.Transform);

Destroy.prototype._init = function (app) {
  enableDestroy(app.server);
};

module.exports = function () {
  return function () {
    return new Destroy();
  }
}
```

and

```js
var stream = require('stream');
var util   = require('util');
var enableDestroy = require('server-destroy');

function Destroy() {}

util.inherits(Destroy, stream.Transform);

module.exports = function () {
  return function () {
    return new Destroy();
  }
}

module.exports._plugin = function (app) {
  enableDestroy(app.server);
}
```

and of course added the middleware to index.js.