### PR TITLE
Add Smart Relay middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var Application = require('./lib/application');
 var courier     = require('./lib/middleware/courier');
 var router      = require('./lib/middleware/router');
 var tattletale  = require('./lib/middleware/tattletale');
+var smartrelay  = require('./lib/middleware/smartrelay');
 
 // expose app constructor
 function coalescent(opts) {
@@ -12,6 +13,7 @@ function coalescent(opts) {
 coalescent.courier    = courier;
 coalescent.router     = router;
 coalescent.tattletale = tattletale;
+coalescent.smartrelay = smartrelay;
 
 // expose module
 module.exports = coalescent;

--- a/lib/middleware/smartrelay.js
+++ b/lib/middleware/smartrelay.js
@@ -1,0 +1,48 @@
+var stream = require('stream');
+var util   = require('util');
+var crypto = require('crypto');
+
+function SmartRelay(socket) {
+  stream.Transform.call(this, {});
+
+  this.socket = socket;
+  this.recentData = [];
+  this.peers = function () { return [] };
+};
+
+util.inherits(SmartRelay, stream.Transform);
+
+SmartRelay.prototype._transform = function (data, encoding, callback) {
+  var _this = this;
+  // create a unique hash of the incoming data
+  var dataHash = crypto.createHash('sha1').update(data).digest('hex');
+  // this should help the hash list scale well enough to match the potential
+  // volume of data incoming from peers
+  // a very talkative peer may pose a problem
+  var maxHashes = this.peers().length * 3
+  var sliceEnd = maxHashes > this.recentData.length
+    ? this.recentData.length + 1
+    : maxHashes;
+
+  if (this.recentData.indexOf(dataHash) === -1) {
+    this.recentData.unshift(dataHash);
+    this.recentData = this.recentData.slice(0, sliceEnd);
+
+    this.peers().forEach(function (peer) {
+      if (peer !== _this.socket) peer.write(data);
+    });
+  }
+
+  callback(null, data);
+};
+
+SmartRelay.prototype._init = function (app, socket) {
+  // wire up connection to peer list
+  this.peers = app.peers.bind(app);
+};
+
+module.exports = function () {
+  return function (socket) {
+    return new SmartRelay(socket);
+  };
+};


### PR DESCRIPTION
This middleware makes forming nonlinear networks (e.g. mesh or just redundant connectivity) possible by preventing data duplication among nodes. It does this by hashing the incoming data so it can check subsequent data to see if it was already received from another node. Data will only be relayed to other nodes if it wasn't previously received.

For best results, each data payload should have a unique identifier and/or timestamp, if there's a chance that multiple payloads could contain the same data (such as in a p2p chat app). This ensures each payload generates a unique hash, even if the relevant content is identical (such as the same sentence sent twice in chat), to prevent data loss.

This middleware is meant as a alternative for the Tattletale middleware—they should not be used in conjunction.